### PR TITLE
7 feat 책 아이템 컴포넌트 구현

### DIFF
--- a/app/books/create/page.tsx
+++ b/app/books/create/page.tsx
@@ -2,13 +2,13 @@
 
 import { useState } from "react";
 import { BookSearchbar } from "@/src/components";
-import type { bookitems } from "@/src/types";
+import type { bookinfo } from "@/src/types";
 import Link from "next/link";
 
 export default function CreateNewBook() {
-  const [bookitems, setBookitems] = useState<bookitems[]>([]);
+  const [bookitems, setBookitems] = useState<bookinfo[]>([]);
 
-  const onSearchbarSubmit = (bookitems: bookitems[]) => {
+  const onSearchbarSubmit = (bookitems: bookinfo[]) => {
     setBookitems(() => bookitems);
   };
 

--- a/app/books/create/page.tsx
+++ b/app/books/create/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { BookSearchbar } from "@/src/components";
+import { BookSearchbar, BookInfoCard } from "@/src/components";
 import type { bookinfo } from "@/src/types";
 import Link from "next/link";
 
@@ -20,7 +20,9 @@ export default function CreateNewBook() {
           <button className="shrink-0 border px-3">취소</button>
         </Link>
       </div>
-      {JSON.stringify(bookitems)}
+      {bookitems.map((item) => (
+        <BookInfoCard key={item.isbn} bookinfo={item} />
+      ))}
     </main>
   );
 }

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,12 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  images: {
+    remotePatterns: [
+      {
+        hostname: "*",
+      },
+    ],
+  },
+};
 
 export default nextConfig;

--- a/src/components/BookInfoCard/BookInfoCard.tsx
+++ b/src/components/BookInfoCard/BookInfoCard.tsx
@@ -1,0 +1,49 @@
+import Image from "next/image";
+import type { BookInfoCard } from "@/src/types";
+
+export default function BookInfoCard({
+  bookinfo,
+  type = "small",
+}: BookInfoCard) {
+  const { title, image, author, publisher } = bookinfo;
+
+  const style = {
+    container: {
+      small: "flex h-28 w-full gap-2 border border-black",
+      large: "w-full flex flex-col items-center gap-4 p-4 border border-black",
+    },
+    image: {
+      small: "aspect-book relative h-full rounded",
+      large: "aspect-book relative w-1/2 rounded",
+    },
+    textbox: {
+      small:
+        "flex w-full flex-col justify-center gap-1 overflow-hidden text-xs",
+      large:
+        "flex w-full flex-col items-center justify-center gap-1  overflow-hidden",
+    },
+    title: {
+      small: "w-full truncate text-sm font-bold pr-4",
+      large: "w-fit max-w-full text-center text-base font-bold",
+    },
+  };
+
+  return (
+    <div className={style.container[type]}>
+      <div className={style.image[type]}>
+        <Image
+          src={image}
+          alt={title}
+          sizes="100px"
+          fill
+          style={{ objectFit: "fill" }}
+        />
+      </div>
+      <div className={style.textbox[type]}>
+        <div className={style.title[type]}>{title}</div>
+        <div className="truncate">{author}</div>
+        <div className="truncate">{publisher}</div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,5 +1,6 @@
 import ReadingBookShelf from "./HomeBookshelf/ReadingBookshelf";
 import LargeButton from "./LargeButton/LargeButton";
 import BookSearchbar from "./BookSearchbar/BookSearchbar";
+import BookInfoCard from "./BookInfoCard/BookInfoCard";
 
-export { ReadingBookShelf, LargeButton, BookSearchbar };
+export { ReadingBookShelf, LargeButton, BookSearchbar, BookInfoCard };

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -14,7 +14,7 @@ interface BookSearchbar {
   handleBookitems: (bookitems: bookitems[]) => void;
 }
 
-interface bookitems {
+interface bookinfo {
   isbn: string;
   title: string;
   image: string;

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -21,3 +21,8 @@ interface bookinfo {
   author: string;
   publisher: string;
 }
+
+interface BookInfoCard {
+  bookinfo: bookinfo;
+  type?: "small" | "large";
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -12,6 +12,9 @@ const config: Config = {
         "gradient-conic":
           "conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))",
       },
+      aspectRatio: {
+        book: "1 / 1.414",
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
# 구현 사항

## 책 카드 (BookInfoCard) 컴포넌트 구현

![화면 기록 2024-02-21 오후 5 54 07](https://github.com/MayOwall/bookmit/assets/97934878/d98d71db-4bb7-4c30-af51-a3f0e6ec0ed1)
aed)

### 컴포넌트 설명

책 카드 컴포넌트를 구현했습니다. (이하 BookInfoCard)

BookInfoCard는 `type` props에 따라 다른 스타일을 보여주게 됩니다.
`type` props 외에도 다음과 같은 props를 받습니다.

|props|필수 여부|값 타입| 설명 |
|--|--|--|--|
|bookinfo|O| {isbn : string, title : string, image : string, author : string, publisher : string} | 책 정보를 담고 있는 객체. |
|type|.| 'small' or 'large'|컴포넌트의 타입을 결정하는 props|

<br/>

## 참고 사항

### 관련 이슈

Close #7 

### 직접적으로 도움이 된 문서

[Next 공식문서 - Image](https://nextjs.org/docs/app/api-reference/components/image#remotepatterns)
[Next 공식문서 - `next/image` Un-configured Host](https://nextjs.org/docs/messages/next-image-unconfigured-host)
[카카오 FE 블로그 - Next/Image를 활용한 이미지 최적화](https://fe-developers.kakaoent.com/2022/220714-next-image/)