### PR TITLE
9 feat 책 등록 페이지 구현

### DIFF
--- a/app/(home)/books/create/page.tsx
+++ b/app/(home)/books/create/page.tsx
@@ -3,9 +3,15 @@
 import Link from "next/link";
 import { useRef, useState } from "react";
 import { getBookitems } from "@/src/api";
-import { BookSearchbar, BookInfoCard } from "@/src/components";
+import {
+  BookSearchbar,
+  BookInfoCard,
+  CraeteBookModalContent,
+} from "@/src/components";
 import { SEARCH_BOOKITEMS_OFFSET } from "@/src/constants";
 import type { bookinfo, bottomButtonStatus } from "@/src/types";
+import { useModalStore } from "@/src/stores";
+import { useRouter } from "next/navigation";
 
 export default function CreateNewBook() {
   const searchPage = useRef(1);
@@ -60,6 +66,8 @@ export default function CreateNewBook() {
     return total <= current * SEARCH_BOOKITEMS_OFFSET;
   };
 
+  const craeteModal = useModalStore((state) => state.createModal);
+
   return (
     <main>
       <div className="flex w-full gap-2 border">
@@ -70,7 +78,13 @@ export default function CreateNewBook() {
       </div>
       <section className="my-4 flex flex-col items-center gap-2">
         {bookitems.map((item) => (
-          <BookInfoCard key={item.isbn} bookinfo={item} />
+          <BookInfoCard
+            key={item.isbn}
+            bookinfo={item}
+            onClick={() =>
+              craeteModal(<CraeteBookModalContent bookinfo={item} />)
+            }
+          />
         ))}
         {bottomButtonStatus === "more" && (
           <button className="m-2 text-blue-500" onClick={onMoreButtonClick}>

--- a/app/(home)/layout.tsx
+++ b/app/(home)/layout.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { useModalStore } from "@/src/stores";
+import { Modal } from "@/src/components";
+
+export default function HomeLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  const modalContent = useModalStore((state) => state.content);
+
+  return (
+    <>
+      {modalContent && <Modal>{modalContent}</Modal>}
+      {children}
+    </>
+  );
+}

--- a/app/(home)/page.tsx
+++ b/app/(home)/page.tsx
@@ -1,14 +1,26 @@
 "use client";
-import { ReadingBookShelf, LargeButton } from "@/src/components";
+
 import Link from "next/link";
+import { useState } from "react";
+import { ReadingBookShelf, LargeButton } from "@/src/components";
+import { bookinfo } from "@/src/types";
 
 export default function Home() {
+  const [selectedbook, setSelectedbook] = useState<bookinfo | null>(null);
+  const handleSelectedBook = (bookinfo: bookinfo) => {
+    if (bookinfo.isbn === selectedbook?.isbn) {
+      setSelectedbook(() => null);
+      return;
+    }
+    setSelectedbook(() => bookinfo);
+  };
   return (
     <main className="flex flex-col gap-1">
-      <ReadingBookShelf />
+      <ReadingBookShelf handleSelectedBook={handleSelectedBook} />
       <Link href="./books/create">
         <LargeButton>새 책 등록하기</LargeButton>
       </Link>
+      {JSON.stringify(selectedbook)}
     </main>
   );
 }

--- a/app/api/searchbook/route.ts
+++ b/app/api/searchbook/route.ts
@@ -1,8 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
+import { SEARCH_BOOKITEMS_OFFSET, FIRST_PAGE } from "@/src/constants";
+import { bookinfo } from "@/src/types";
 
 const naverClientId = process.env.NAVER_CLIENT_ID!;
 const naverClientSecret = process.env.NAVER_CLIENT_SECRET!;
-const getHeaders = {
+const headers = {
   "X-Naver-Client-Id": naverClientId,
   "X-Naver-Client-Secret": naverClientSecret,
 };
@@ -10,18 +12,20 @@ const getHeaders = {
 export async function GET(request: NextRequest) {
   const searchParams = request.nextUrl.searchParams;
   const keyword = searchParams.get("keyword");
+  const page = searchParams.get("page") || FIRST_PAGE;
 
+  const start = (Number(page) - 1) * SEARCH_BOOKITEMS_OFFSET + 1;
   const res = await fetch(
-    `https://openapi.naver.com/v1/search/book.json?display=50&query=${keyword}`,
-    { headers: getHeaders },
+    `https://openapi.naver.com/v1/search/book.json?display=${SEARCH_BOOKITEMS_OFFSET}&start=${start}&query=${keyword}`,
+    { headers },
   );
 
-  const { items } = await res.json();
-  const bookitems = items.map(
-    ({ title, image, author, publisher, isbn }: any) => {
+  const { total, items } = await res.json();
+  const bookitems: bookinfo = items.map(
+    ({ title, image, author, publisher, isbn }: bookinfo) => {
       return { title, image, author, publisher, isbn };
     },
   );
 
-  return NextResponse.json({ bookitems });
+  return NextResponse.json({ total, bookitems });
 }

--- a/app/books/create/page.tsx
+++ b/app/books/create/page.tsx
@@ -1,28 +1,86 @@
 "use client";
 
-import { useState } from "react";
-import { BookSearchbar, BookInfoCard } from "@/src/components";
-import type { bookinfo } from "@/src/types";
 import Link from "next/link";
+import { useRef, useState } from "react";
+import { getBookitems } from "@/src/api";
+import { BookSearchbar, BookInfoCard } from "@/src/components";
+import { SEARCH_BOOKITEMS_OFFSET } from "@/src/constants";
+import type { bookinfo, bottomButtonStatus } from "@/src/types";
 
 export default function CreateNewBook() {
+  const searchPage = useRef(1);
+  const searchword = useRef("");
   const [bookitems, setBookitems] = useState<bookinfo[]>([]);
+  const [bottomButtonStatus, setBottomButtonStatus] =
+    useState<bottomButtonStatus>("nonDisplay");
 
-  const onSearchbarSubmit = (bookitems: bookinfo[]) => {
-    setBookitems(() => bookitems);
+  // 검색어가 제출되었을 때의 동작
+  const onSearchbarSubmit = async (keyword: string) => {
+    const { total, bookitems } = await getBookitems(
+      keyword,
+      searchPage.current,
+    );
+
+    searchword.current = keyword;
+    handleBookitems(total, bookitems);
+  };
+
+  // 새로운 검색 결과를 반영
+  const handleBookitems = (total: number, bookitems: bookinfo[]) => {
+    if (!total) {
+      setBottomButtonStatus(() => "nobooks");
+      return;
+    }
+
+    searchPage.current += 1;
+    setBookitems(bookitems);
+    setBottomButtonStatus(() => "more");
+  };
+
+  // 더보기 버튼을 클릭했을 때의 동작
+  const onMoreButtonClick = () => {
+    handleNextBookitems();
+  };
+
+  // 다음 검색 결과를 반영
+  const handleNextBookitems = async () => {
+    if (!searchword.current) return;
+
+    const res = await getBookitems(searchword.current, searchPage.current);
+    const nextBookitems = [...bookitems, ...res.bookitems];
+    setBookitems(() => nextBookitems);
+
+    isLastPage(res.total, searchPage.current)
+      ? setBottomButtonStatus(() => "end")
+      : (searchPage.current += 1);
+  };
+
+  // 마지막 페이지인지 판별
+  const isLastPage = (total: number, current: number) => {
+    return total <= current * SEARCH_BOOKITEMS_OFFSET;
   };
 
   return (
     <main>
       <div className="flex w-full gap-2 border">
-        <BookSearchbar handleBookitems={onSearchbarSubmit} />
+        <BookSearchbar handleSubmit={onSearchbarSubmit} />
         <Link href="/">
           <button className="shrink-0 border px-3">취소</button>
         </Link>
       </div>
-      {bookitems.map((item) => (
-        <BookInfoCard key={item.isbn} bookinfo={item} />
-      ))}
+      <section className="my-4 flex flex-col items-center gap-2">
+        {bookitems.map((item) => (
+          <BookInfoCard key={item.isbn} bookinfo={item} />
+        ))}
+        {bottomButtonStatus === "more" && (
+          <button className="m-2 text-blue-500" onClick={onMoreButtonClick}>
+            더 보기
+          </button>
+        )}
+        {bottomButtonStatus === "end" && (
+          <div className="end m-2">마지막 책 입니다</div>
+        )}
+      </section>
     </main>
   );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "next": "14.1.0",
         "react": "^18",
-        "react-dom": "^18"
+        "react-dom": "^18",
+        "zustand": "^4.5.1"
       },
       "devDependencies": {
         "@types/node": "^20",
@@ -467,13 +468,13 @@
       "version": "15.7.11",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.11.tgz",
       "integrity": "sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/react": {
       "version": "18.2.57",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.57.tgz",
       "integrity": "sha512-ZvQsktJgSYrQiMirAN60y4O/LRevIV8hUzSOSNB6gfR3/o3wCBFQx3sPwIYtuDMeiVgsSS3UzCV26tEzgnfvQw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -493,7 +494,7 @@
       "version": "0.16.8",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.8.tgz",
       "integrity": "sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@typescript-eslint/parser": {
       "version": "6.21.0",
@@ -1223,7 +1224,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -4693,6 +4694,14 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -4915,6 +4924,33 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.1.tgz",
+      "integrity": "sha512-XlauQmH64xXSC1qGYNv00ODaQ3B+tNPoy22jv2diYiP4eoDKr9LA+Bh5Bc3gplTrFdb6JVI+N4kc1DZ/tbtfPg==",
+      "dependencies": {
+        "use-sync-external-store": "1.2.0"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "next": "14.1.0",
     "react": "^18",
-    "react-dom": "^18"
+    "react-dom": "^18",
+    "zustand": "^4.5.1"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,0 +1,5 @@
+export const getBookitems = async (keyword: string, page: number) => {
+  const data = await fetch(`/api/searchbook?keyword=${keyword}&page=${page}`);
+  const { total, bookitems } = await data.json();
+  return { total, bookitems };
+};

--- a/src/components/BookInfoCard/BookInfoCard.tsx
+++ b/src/components/BookInfoCard/BookInfoCard.tsx
@@ -4,6 +4,7 @@ import type { BookInfoCard } from "@/src/types";
 export default function BookInfoCard({
   bookinfo,
   type = "small",
+  onClick,
 }: BookInfoCard) {
   const { title, image, author, publisher } = bookinfo;
 
@@ -29,7 +30,7 @@ export default function BookInfoCard({
   };
 
   return (
-    <div className={style.container[type]}>
+    <div className={style.container[type]} onClick={onClick}>
       <div className={style.image[type]}>
         <Image
           src={image}

--- a/src/components/BookSearchbar/BookSearchbar.tsx
+++ b/src/components/BookSearchbar/BookSearchbar.tsx
@@ -1,25 +1,22 @@
 "use client";
 
-import { useState } from "react";
 import type { BookSearchbar } from "@/src/types";
+import { useState } from "react";
 
-export default function BookSearchbar({ handleBookitems }: BookSearchbar) {
+export default function BookSearchbar({ handleSubmit }: BookSearchbar) {
   const [keyword, setKeyword] = useState("");
-
   const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { value } = e.currentTarget;
     setKeyword(() => value);
   };
 
-  const onSearchbarSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+  const onSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    const data = await fetch(`/api/searchbook?keyword=${keyword}`);
-    const { bookitems } = await data.json();
-    handleBookitems(bookitems);
+    handleSubmit(keyword);
   };
 
   return (
-    <form className="w-full" onSubmit={onSearchbarSubmit}>
+    <form className="w-full" onSubmit={onSubmit}>
       <input
         className="size-1 h-10 w-full rounded border px-2 outline-none"
         placeholder="검색할 책을 입력해주세요"

--- a/src/components/HomeBookshelf/ReadingBookshelf.tsx
+++ b/src/components/HomeBookshelf/ReadingBookshelf.tsx
@@ -1,9 +1,28 @@
-import type { ReadingBookShelf } from "@/src/types";
+import type { ReadingBookShelf, bookinfo } from "@/src/types";
+import Image from "next/image";
 
-export default function ReadingBookShelf({ books }: ReadingBookShelf) {
+export default function ReadingBookShelf({
+  handleSelectedBook,
+}: ReadingBookShelf) {
+  const readingbooks = localStorage.getItem("readingbooks") || "[]";
+  const bookitems = JSON.parse(readingbooks).map((book: bookinfo) => (
+    <div
+      key={book.isbn}
+      className="relative aspect-book h-full shrink-0 overflow-auto rounded"
+      onClick={() => handleSelectedBook(book)}
+    >
+      <Image
+        src={book.image}
+        alt={book.title}
+        fill
+        sizes="100px"
+        style={{ objectFit: `contain` }}
+      />
+    </div>
+  ));
   return (
-    <div className="flex min-h-40 items-center gap-4 overflow-auto border border-black">
-      {books || <EmptyBookShelf />}
+    <div className="flex h-40 items-center gap-4 overflow-auto border border-black p-4">
+      {bookitems.length ? bookitems : <EmptyBookShelf />}
     </div>
   );
 }

--- a/src/components/Modal/Contents/CreateBookModalContent.tsx
+++ b/src/components/Modal/Contents/CreateBookModalContent.tsx
@@ -1,0 +1,40 @@
+import { useRouter } from "next/navigation";
+import { useModalStore } from "@/src/stores";
+import { BookInfoCard, LargeButton } from "@/src/components";
+import type { bookinfo } from "@/src/types";
+
+export default function CreateBookModalContent({
+  bookinfo,
+}: {
+  bookinfo: bookinfo;
+}) {
+  const router = useRouter();
+  const remoteModal = useModalStore((state) => state.remoteModal);
+
+  const onSubmit = () => {
+    handleReadingbooks(bookinfo);
+    remoteModal();
+    router.push("/");
+  };
+
+  const handleReadingbooks = (bookinfo: bookinfo) => {
+    const localReadingBooks = localStorage.getItem("readingbooks");
+    const readingBooks = localReadingBooks ? JSON.parse(localReadingBooks) : [];
+    const nextReadingBooks = [...readingBooks, bookinfo];
+
+    localStorage.setItem("readingbooks", JSON.stringify(nextReadingBooks));
+  };
+
+  return (
+    <section className="flex flex-col items-center gap-8">
+      <h1 className="text-xl font-bold">이 책을 등록할까요?</h1>
+      <BookInfoCard type="large" bookinfo={bookinfo} />
+      <div className="flex w-full flex-col items-center gap-2">
+        <LargeButton onClick={onSubmit}>등록하기</LargeButton>
+        <button className="text-neutral-500" onClick={remoteModal}>
+          취소
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -1,0 +1,9 @@
+import type { Modal } from "@/src/types";
+
+export default function Modal({ children }: Modal) {
+  return (
+    <div className="absolute left-0 top-0 z-10 flex h-lvh w-lvw items-center justify-center bg-black/[.2] p-4">
+      <div className="w-full rounded-xl bg-white p-4 py-8">{children}</div>
+    </div>
+  );
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -2,5 +2,14 @@ import ReadingBookShelf from "./HomeBookshelf/ReadingBookshelf";
 import LargeButton from "./LargeButton/LargeButton";
 import BookSearchbar from "./BookSearchbar/BookSearchbar";
 import BookInfoCard from "./BookInfoCard/BookInfoCard";
+import Modal from "./Modal/Modal";
+import CraeteBookModalContent from "./Modal/Contents/CreateBookModalContent";
 
-export { ReadingBookShelf, LargeButton, BookSearchbar, BookInfoCard };
+export {
+  ReadingBookShelf,
+  LargeButton,
+  BookSearchbar,
+  BookInfoCard,
+  Modal,
+  CraeteBookModalContent,
+};

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,0 +1,2 @@
+export const SEARCH_BOOKITEMS_OFFSET = 50;
+export const FIRST_PAGE = 1;

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -1,0 +1,9 @@
+import { create } from "zustand";
+import type { ReactNode } from "react";
+import type { useModalState } from "@/src/types";
+
+export const useModalStore = create<useModalState>((set) => ({
+  content: null,
+  createModal: (nextContent: ReactNode) => set({ content: nextContent }),
+  remoteModal: () => set({ content: null }),
+}));

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -1,7 +1,7 @@
 import { ReactNode } from "react";
 
 interface ReadingBookShelf {
-  books?: ReactNode;
+  handleSelectedBook: (bookinfo: bookinfo) => void;
 }
 
 interface LargeButton {

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -25,6 +25,17 @@ interface bookinfo {
 interface BookInfoCard {
   bookinfo: bookinfo;
   type?: "small" | "large";
+  onClick?: () => void;
 }
 
 type bottomButtonStatus = "nonDisplay" | "more" | "nobooks" | "end";
+
+interface Modal {
+  children: ReactNode;
+}
+
+interface useModalState {
+  content: null | ReactNode;
+  createModal: (nextContent: ReactNode) => void;
+  remoteModal: () => void;
+}

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -11,7 +11,7 @@ interface LargeButton {
 }
 
 interface BookSearchbar {
-  handleBookitems: (bookitems: bookitems[]) => void;
+  handleSubmit: (keyword: string) => void;
 }
 
 interface bookinfo {
@@ -26,3 +26,5 @@ interface BookInfoCard {
   bookinfo: bookinfo;
   type?: "small" | "large";
 }
+
+type bottomButtonStatus = "nonDisplay" | "more" | "nobooks" | "end";


### PR DESCRIPTION
# 책 등록 페이지 및 기능 구현

## 구현 기능 미리보기

![화면 기록 2024-02-22 오전 11 26 26](https://github.com/MayOwall/bookmit/assets/97934878/23f39f6c-7a03-4e20-a918-446f3f35d5a2)

<br/>

## 구현 사항

### 책 검색 결과 반영 기능 구현

책 검색시 검색된 책 리스트 결과를 화면에 반영하는 기능을 구현했습니다.
화면에 랜더링 된 책 아이템을 클릭하면 책을 등록할지 여부를 물어보는 모달이 생성됩니다.

### 책 등록 모달 기능 구현 (feat. Zustand)

책을 등록할지에 대해 물어보는 모달 기능을 구현했습니다.

#### 책 등록

모달의 등록하기 버튼을 누르면 Localstorage에 해당 책 정보를 저장한 후,
홈 페이지로 이동합니다.

#### 등록 취소

모달의 취소 버튼을 누르면 모달이 해제됩니다.

#### 구현 상세

모달은 기본적으로 Next의 Layout.ts를 통해 뷰포트의 최상단에 랜더링됩니다.
Zustand를 통해 모달 내부의 content의 상태를 관리하면서
content가 존재하면 모달을 랜더링하고, content가 존재하지 않으면 모달이 랜더링 되지 않도록 했습니다.

<br/>

## 관련 사항

### 관련된 이슈
 
Close #8 

### 직접적으로 도움이 된 문서

[Next 공식문서 - useRouter](https://nextjs.org/docs/app/api-reference/functions/use-router)
[Zustand 공식문서](https://docs.pmnd.rs/zustand/getting-started/introduction)
[Zustand 내부 로직 설명 글](https://www.nextree.io/zustand/)
