### PR TITLE
feat: 홈페이지 북밋 전체 리스트 기능 구현 (3h/3h)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ yarn-error.log*
 
 # local env files
 .env*.local
+dummy.json
 
 # vercel
 .vercel

--- a/app/(home)/page.tsx
+++ b/app/(home)/page.tsx
@@ -2,10 +2,12 @@
 
 import Link from "next/link";
 import { useState, useEffect } from "react";
+import { getReadingbooks, getAllBookmits } from "@/src/api";
 import { ReadingBookShelf, LargeButton } from "@/src/components";
 
 export default function Home() {
   const [readingbooks, setReadingbooks] = useState([]);
+  const [bookmits, setBookmits] = useState([]);
   const [selectedbookIsbn, setSelectedbookIsbn] = useState<string | null>(null);
 
   const handleSelectedBook = (isbn: string) => {
@@ -13,9 +15,13 @@ export default function Home() {
   };
 
   useEffect(() => {
-    const localReadingbooks = localStorage.getItem("readingbooks");
-    const readingbooks = localReadingbooks ? JSON.parse(localReadingbooks) : [];
+    const readingbooks = getReadingbooks();
     setReadingbooks(() => readingbooks);
+  }, []);
+
+  useEffect(() => {
+    const bookmits = getAllBookmits();
+    setBookmits(() => bookmits);
   }, []);
 
   return (
@@ -30,7 +36,8 @@ export default function Home() {
           <LargeButton>새 책 등록하기</LargeButton>
         </Link>
       )}
-      {selectedbookIsbn}
+      <div>{selectedbookIsbn || "."}</div>
+      {JSON.stringify(bookmits)}
     </main>
   );
 }

--- a/app/(home)/page.tsx
+++ b/app/(home)/page.tsx
@@ -20,14 +20,35 @@ export default function Home() {
 
   return (
     <main className="flex flex-col gap-1">
+      <NewBookButton isReadingbookExist={!!readingbooks.length} />
       <ReadingBookShelf
         readingbooks={readingbooks}
         onClick={handleSelectedBook}
       />
-      <Link href="./books/create">
-        <LargeButton>새 책 등록하기</LargeButton>
-      </Link>
+      {!readingbooks.length && (
+        <Link href="./books/create">
+          <LargeButton>새 책 등록하기</LargeButton>
+        </Link>
+      )}
       {selectedbookIsbn}
     </main>
+  );
+}
+
+function NewBookButton({
+  isReadingbookExist,
+}: {
+  isReadingbookExist: boolean;
+}) {
+  return (
+    <div className="text-right">
+      <Link href="/books/create">
+        <button
+          className={`${!isReadingbookExist && "invisible"} text-sm text-blue-500`}
+        >
+          새 책 등록
+        </button>
+      </Link>
+    </div>
   );
 }

--- a/app/(home)/page.tsx
+++ b/app/(home)/page.tsx
@@ -3,7 +3,12 @@
 import Link from "next/link";
 import { useState, useEffect } from "react";
 import { getReadingbooks, getAllBookmits } from "@/src/api";
-import { ReadingBookShelf, LargeButton } from "@/src/components";
+import {
+  ReadingBookShelf,
+  LargeButton,
+  BookmitsByDate,
+} from "@/src/components";
+import type { BookmitsByDate as bookmitsByDate } from "@/src/types";
 
 export default function Home() {
   const [readingbooks, setReadingbooks] = useState([]);
@@ -36,8 +41,11 @@ export default function Home() {
           <LargeButton>새 책 등록하기</LargeButton>
         </Link>
       )}
-      <div>{selectedbookIsbn || "."}</div>
-      {JSON.stringify(bookmits)}
+      <div>선택 : {selectedbookIsbn || "X"}</div>
+      {!!bookmits &&
+        bookmits.map((bookmitsByDate: bookmitsByDate) => (
+          <BookmitsByDate key={bookmitsByDate.date} {...bookmitsByDate} />
+        ))}
     </main>
   );
 }

--- a/app/(home)/page.tsx
+++ b/app/(home)/page.tsx
@@ -1,22 +1,33 @@
 "use client";
 
 import Link from "next/link";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { ReadingBookShelf, LargeButton } from "@/src/components";
-import { bookinfo } from "@/src/types";
 
 export default function Home() {
-  const [selectedbook, setSelectedbook] = useState<bookinfo | null>(null);
-  const handleSelectedBook = (bookinfo: bookinfo) => {
-    setSelectedbook(() => bookinfo);
+  const [readingbooks, setReadingbooks] = useState([]);
+  const [selectedbookIsbn, setSelectedbookIsbn] = useState<string | null>(null);
+
+  const handleSelectedBook = (isbn: string) => {
+    setSelectedbookIsbn(() => (isbn === selectedbookIsbn ? null : isbn));
   };
+
+  useEffect(() => {
+    const localReadingbooks = localStorage.getItem("readingbooks");
+    const readingbooks = localReadingbooks ? JSON.parse(localReadingbooks) : [];
+    setReadingbooks(() => readingbooks);
+  }, []);
+
   return (
     <main className="flex flex-col gap-1">
-      <ReadingBookShelf handleSelectedBook={handleSelectedBook} />
+      <ReadingBookShelf
+        readingbooks={readingbooks}
+        onClick={handleSelectedBook}
+      />
       <Link href="./books/create">
         <LargeButton>새 책 등록하기</LargeButton>
       </Link>
-      {JSON.stringify(selectedbook)}
+      {selectedbookIsbn}
     </main>
   );
 }

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -3,3 +3,15 @@ export const getBookitems = async (keyword: string, page: number) => {
   const { total, bookitems } = await data.json();
   return { total, bookitems };
 };
+
+export const getReadingbooks = () => {
+  const localReadingbooks = localStorage.getItem("readingbooks");
+  const readingbooks = localReadingbooks ? JSON.parse(localReadingbooks) : [];
+  return readingbooks;
+};
+
+export const getAllBookmits = () => {
+  const localBookmits = localStorage.getItem("bookmits");
+  const allBookmits = localBookmits ? JSON.parse(localBookmits) : [];
+  return allBookmits;
+};

--- a/src/components/BookmitsByDate/BookmitsByDate.tsx
+++ b/src/components/BookmitsByDate/BookmitsByDate.tsx
@@ -1,0 +1,26 @@
+import { BookmitCard, BookmitsByDate } from "@/src/types";
+
+export default function BookmitsByDate({ date, bookmits }: BookmitsByDate) {
+  return (
+    <div className="my-6 flex w-full flex-col gap-2">
+      <div className="font-bold">{date}</div>
+      {bookmits.map((bookmit) => (
+        <BookmitCard key={bookmit._id} {...bookmit} />
+      ))}
+    </div>
+  );
+}
+
+function BookmitCard({ _id, bookinfo, startPage, endPage }: BookmitCard) {
+  return (
+    <div
+      className="rounded-lg border border-neutral-400 bg-white p-2"
+      data-id={_id}
+    >
+      <div data-isbn={bookinfo.isbn}>{bookinfo.title}</div>
+      <div className="text-sm">
+        p.{startPage} - {endPage}
+      </div>
+    </div>
+  );
+}

--- a/src/components/HomeBookshelf/ReadingBookshelf.tsx
+++ b/src/components/HomeBookshelf/ReadingBookshelf.tsx
@@ -1,36 +1,41 @@
-import type { ReadingBookShelf, bookinfo } from "@/src/types";
 import Image from "next/image";
-import { useEffect, useState } from "react";
+import type { ReadingBookShelf } from "@/src/types";
 
 export default function ReadingBookShelf({
-  handleSelectedBook,
+  readingbooks,
+  onClick,
 }: ReadingBookShelf) {
-  const [bookitems, setBookitems] = useState(null);
-  useEffect(() => {
-    const readingbooks = localStorage.getItem("readingbooks") || "[]";
-    const bookitems = JSON.parse(readingbooks).map((book: bookinfo) => (
-      <div
-        key={book.isbn}
-        className="relative aspect-book h-full shrink-0 overflow-auto rounded"
-        onClick={() => {
-          handleSelectedBook(book);
-        }}
-      >
-        <Image
-          src={book.image}
-          alt={book.title}
-          fill
-          sizes="100px"
-          style={{ objectFit: `contain` }}
-        />
-      </div>
-    ));
-    setBookitems(() => bookitems);
-  }, []);
   return (
     <div className="flex h-40 items-center gap-4 overflow-auto border border-black p-4">
-      {bookitems ? bookitems : <EmptyBookShelf />}
+      {readingbooks && readingbooks.length ? (
+        <ReadingBookItems readingbooks={readingbooks} onClick={onClick} />
+      ) : (
+        <EmptyBookShelf />
+      )}
     </div>
+  );
+}
+
+function ReadingBookItems({ readingbooks, onClick }: ReadingBookShelf) {
+  return (
+    <>
+      {readingbooks.map((book) => (
+        <div
+          key={book.isbn}
+          className="relative aspect-book h-full shrink-0 overflow-auto rounded"
+          onClick={() => onClick(book.isbn)}
+        >
+          <Image
+            src={book.image}
+            alt={book.title}
+            fill
+            sizes="100px"
+            style={{ objectFit: "contain" }}
+            priority
+          />
+        </div>
+      ))}
+    </>
   );
 }
 

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -4,6 +4,7 @@ import BookSearchbar from "./BookSearchbar/BookSearchbar";
 import BookInfoCard from "./BookInfoCard/BookInfoCard";
 import Modal from "./Modal/Modal";
 import CraeteBookModalContent from "./Modal/Contents/CreateBookModalContent";
+import BookmitsByDate from "./BookmitsByDate/BookmitsByDate";
 
 export {
   ReadingBookShelf,
@@ -12,4 +13,5 @@ export {
   BookInfoCard,
   Modal,
   CraeteBookModalContent,
+  BookmitsByDate,
 };

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,0 +1,3 @@
+import useLocalStorage from "./useLocalStorage";
+
+export { useLocalStorage };

--- a/src/hooks/useLocalStorage.tsx
+++ b/src/hooks/useLocalStorage.tsx
@@ -1,0 +1,28 @@
+import { useState } from "react";
+
+export default function useLocalStorage(key: string, initialValue: any) {
+  const stateInitializer = () => {
+    try {
+      const value = localStorage.getItem(key);
+      const state = value ? JSON.parse(value) : initialValue;
+      return state;
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  const [state, setState] = useState(stateInitializer);
+
+  const setValue = (value: unknown) => {
+    try {
+      const valueToStore =
+        value instanceof Function ? (state: unknown) => value(state) : value;
+      localStorage.setItem(key, JSON.stringify(valueToStore));
+      setState(value);
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  return [state, setValue];
+}

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -40,3 +40,24 @@ interface useModalState {
   createModal: (nextContent: ReactNode) => void;
   remoteModal: () => void;
 }
+
+interface bookmitInfo {
+  _id: string;
+  bookinfo: {
+    title: string;
+    isbn: string;
+  };
+  startPage: number;
+  endPage: number;
+}
+
+interface BookmitCard extends bookmitInfo {}
+
+interface BookmitsByDate {
+  date: string;
+  bookmits: bookmitInfo[];
+}
+
+interface BookmitList {
+  bookmits: BookmitsByDate[];
+}

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -1,7 +1,8 @@
 import { ReactNode } from "react";
 
 interface ReadingBookShelf {
-  handleSelectedBook: (bookinfo: bookinfo) => void;
+  readingbooks: bookinfo[];
+  onClick: (isbn: string) => void;
 }
 
 interface LargeButton {


### PR DESCRIPTION
# 구현 사항

## 읽고 있는 책 여부에 따른 새 책 등록 랜더링 방식 구현

### 동작 이미지

#### 읽고 있는 책이 없을 때 🙅🏻‍♀️

![image](https://github.com/MayOwall/bookmit/assets/97934878/a471166c-534f-416a-a573-46a7d0585b78)

#### 읽고 있는 책이 있을 때 🙆🏻‍♀️

![image](https://github.com/MayOwall/bookmit/assets/97934878/6fd40b87-014e-4997-9608-1f7ebfc48ce4)


### 설명

읽고 있는 책이 있다면 페이지 우측 상단에,
읽고 있는 책이 없다면 페이지 중간에 새 책 등록 버튼이 나타납니다.

<br/>

## 전체 북밋 리스트 구현

### 동작 이미지

![image](https://github.com/MayOwall/bookmit/assets/97934878/8f8ce6b2-aba2-46b3-be37-60e9ef177cca)


### 설명

전체 북밋 리스트를 구현했습니다.
페이지 진입시 로컬스토리지의 북밋 데이터를 바탕으로 북밋 리스트가 랜더링됩니다.


<br/>