### PR TITLE
feat 홈페이지 책 선택에 따른 로직 구현 (1h/4h)

### DIFF
--- a/app/(home)/bookmit/create/page.tsx
+++ b/app/(home)/bookmit/create/page.tsx
@@ -1,0 +1,3 @@
+export default function BookmitCreate() {
+  return <div>create new bookmit :D</div>;
+}

--- a/app/(home)/page.tsx
+++ b/app/(home)/page.tsx
@@ -38,6 +38,7 @@ export default function Home() {
       <NewBookButton isReadingbookExist={!!readingbooks.length} />
       <ReadingBookShelf
         readingbooks={readingbooks}
+        selectedBook={selectedBook}
         onClick={handleSelectedBook}
       />
       {!readingbooks.length && (

--- a/app/(home)/page.tsx
+++ b/app/(home)/page.tsx
@@ -8,15 +8,19 @@ import {
   LargeButton,
   BookmitsByDate,
 } from "@/src/components";
-import type { BookmitsByDate as bookmitsByDate } from "@/src/types";
+import type { BookmitsByDate as bookmitsByDate, bookinfo } from "@/src/types";
 
 export default function Home() {
   const [readingbooks, setReadingbooks] = useState([]);
   const [bookmits, setBookmits] = useState([]);
-  const [selectedbookIsbn, setSelectedbookIsbn] = useState<string | null>(null);
+  const [selectedBook, setSelectedBook] = useState<bookinfo | null>(null);
 
-  const handleSelectedBook = (isbn: string) => {
-    setSelectedbookIsbn(() => (isbn === selectedbookIsbn ? null : isbn));
+  const handleSelectedBook = (bookinfo: bookinfo) => {
+    if (bookinfo.isbn === selectedBook?.isbn) {
+      setSelectedBook(null);
+      return;
+    }
+    setSelectedBook(() => bookinfo);
   };
 
   useEffect(() => {
@@ -41,7 +45,7 @@ export default function Home() {
           <LargeButton>새 책 등록하기</LargeButton>
         </Link>
       )}
-      <div>선택 : {selectedbookIsbn || "X"}</div>
+      <div>선택 : {JSON.stringify(selectedBook)}</div>
       {!!bookmits &&
         bookmits.map((bookmitsByDate: bookmitsByDate) => (
           <BookmitsByDate key={bookmitsByDate.date} {...bookmitsByDate} />

--- a/app/(home)/page.tsx
+++ b/app/(home)/page.tsx
@@ -46,7 +46,13 @@ export default function Home() {
           <LargeButton>새 책 등록하기</LargeButton>
         </Link>
       )}
-      <div>선택 : {JSON.stringify(selectedBook)}</div>
+      {selectedBook && (
+        <Link
+          href={`/bookmit/create?isbn=${selectedBook.isbn}&title=${selectedBook.title}`}
+        >
+          <LargeButton>새 북밋 생성</LargeButton>
+        </Link>
+      )}
       {!!bookmits &&
         bookmits.map((bookmitsByDate: bookmitsByDate) => (
           <BookmitsByDate key={bookmitsByDate.date} {...bookmitsByDate} />

--- a/app/(home)/page.tsx
+++ b/app/(home)/page.tsx
@@ -2,7 +2,11 @@
 
 import Link from "next/link";
 import { useState, useEffect } from "react";
-import { getReadingbooks, getAllBookmits } from "@/src/api";
+import {
+  getReadingbooks,
+  getAllBookmits,
+  getSelectedBookmits,
+} from "@/src/api";
 import {
   ReadingBookShelf,
   LargeButton,
@@ -12,7 +16,7 @@ import type { BookmitsByDate as bookmitsByDate, bookinfo } from "@/src/types";
 
 export default function Home() {
   const [readingbooks, setReadingbooks] = useState([]);
-  const [bookmits, setBookmits] = useState([]);
+  const [bookmits, setBookmits] = useState<bookmitsByDate[]>([]);
   const [selectedBook, setSelectedBook] = useState<bookinfo | null>(null);
 
   const handleSelectedBook = (bookinfo: bookinfo) => {
@@ -32,6 +36,16 @@ export default function Home() {
     const bookmits = getAllBookmits();
     setBookmits(() => bookmits);
   }, []);
+
+  useEffect(() => {
+    if (!selectedBook) {
+      const bookmits = getAllBookmits();
+      setBookmits(() => bookmits);
+      return;
+    }
+    const bookmits = getSelectedBookmits(selectedBook.isbn);
+    setBookmits(() => bookmits);
+  }, [selectedBook]);
 
   return (
     <main className="flex flex-col gap-1">
@@ -53,10 +67,15 @@ export default function Home() {
           <LargeButton>새 북밋 생성</LargeButton>
         </Link>
       )}
-      {!!bookmits &&
+      {!!bookmits.length &&
         bookmits.map((bookmitsByDate: bookmitsByDate) => (
           <BookmitsByDate key={bookmitsByDate.date} {...bookmitsByDate} />
         ))}
+      {!bookmits.length && (
+        <div className="m-2 text-center text-sm text-neutral-400">
+          작성한 북밋이 없어요
+        </div>
+      )}
     </main>
   );
 }

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,3 +1,5 @@
+import { BookmitsByDate } from "../types";
+
 export const getBookitems = async (keyword: string, page: number) => {
   const data = await fetch(`/api/searchbook?keyword=${keyword}&page=${page}`);
   const { total, bookitems } = await data.json();
@@ -12,6 +14,25 @@ export const getReadingbooks = () => {
 
 export const getAllBookmits = () => {
   const localBookmits = localStorage.getItem("bookmits");
-  const allBookmits = localBookmits ? JSON.parse(localBookmits) : [];
+  const allBookmits: BookmitsByDate[] = localBookmits
+    ? JSON.parse(localBookmits)
+    : [];
   return allBookmits;
+};
+
+export const getSelectedBookmits = (isbn: string) => {
+  const allBookmits = getAllBookmits();
+  const selectedBookmits = allBookmits
+    .map(({ date, bookmits }) => {
+      const selectedBookmits = bookmits.filter(
+        (bookmit) => bookmit.bookinfo.isbn === isbn,
+      );
+      return {
+        date,
+        bookmits: selectedBookmits,
+      };
+    })
+    .filter(({ bookmits }) => !!bookmits.length);
+
+  return selectedBookmits;
 };

--- a/src/components/HomeBookshelf/ReadingBookshelf.tsx
+++ b/src/components/HomeBookshelf/ReadingBookshelf.tsx
@@ -3,12 +3,17 @@ import type { ReadingBookShelf } from "@/src/types";
 
 export default function ReadingBookShelf({
   readingbooks,
+  selectedBook,
   onClick,
 }: ReadingBookShelf) {
   return (
     <div className="flex h-40 items-center gap-4 overflow-auto border border-black p-4">
       {readingbooks && readingbooks.length ? (
-        <ReadingBookItems readingbooks={readingbooks} onClick={onClick} />
+        <ReadingBookItems
+          readingbooks={readingbooks}
+          selectedBook={selectedBook}
+          onClick={onClick}
+        />
       ) : (
         <EmptyBookShelf />
       )}
@@ -16,13 +21,17 @@ export default function ReadingBookShelf({
   );
 }
 
-function ReadingBookItems({ readingbooks, onClick }: ReadingBookShelf) {
+function ReadingBookItems({
+  readingbooks,
+  selectedBook,
+  onClick,
+}: ReadingBookShelf) {
   return (
     <>
       {readingbooks.map((book) => (
         <div
           key={book.isbn}
-          className="relative aspect-book h-full shrink-0 overflow-auto rounded"
+          className={`relative aspect-book h-full shrink-0 overflow-auto rounded ${selectedBook && selectedBook.isbn !== book.isbn ? "opacity-50" : ""}`}
           onClick={() => onClick(book)}
         >
           <Image

--- a/src/components/HomeBookshelf/ReadingBookshelf.tsx
+++ b/src/components/HomeBookshelf/ReadingBookshelf.tsx
@@ -23,7 +23,7 @@ function ReadingBookItems({ readingbooks, onClick }: ReadingBookShelf) {
         <div
           key={book.isbn}
           className="relative aspect-book h-full shrink-0 overflow-auto rounded"
-          onClick={() => onClick(book.isbn)}
+          onClick={() => onClick(book)}
         >
           <Image
             src={book.image}

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -2,6 +2,7 @@ import { ReactNode } from "react";
 
 interface ReadingBookShelf {
   readingbooks: bookinfo[];
+  selectedBook: bookinfo | null;
   onClick: (bookinfo: bookinfo) => void;
 }
 

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -2,7 +2,7 @@ import { ReactNode } from "react";
 
 interface ReadingBookShelf {
   readingbooks: bookinfo[];
-  onClick: (isbn: string) => void;
+  onClick: (bookinfo: bookinfo) => void;
 }
 
 interface LargeButton {


### PR DESCRIPTION
# 홈페이지 책 선택에 따른 로직 구현

## 기능 미리보기 

<img src='https://github.com/MayOwall/bookmit/assets/97934878/fcaf9e5a-acc4-42e7-ba14-a5bc462dbc41' width=200 />

<br/>

## 선택한 책에 따른 북밋 생성 버튼 랜더링 구현

### ✅ 책 선택시 해당 책에 대한 북밋 생성 버튼 활성화

책을 선택하면 북밋 생성 버튼이 나타납니다.
선택한 책을 제외한 다른 책은 투명도가 50%로 줄어듭니다.

북밋 생성 버튼을 클릭하면 해당 책의 북밋 생성 페이지로 이동합니다.
(현재 라우팅만 구현)

### ✅ 선택한 책을 다시 선택할 시 선택 해제

선택한 책을 다시 클릭하면 책 선택이 해제됩니다.
북밋 생성 버튼 또한 비활성화 됩니다.

<br/>

## 선택한 책에 따른 북밋 리스트 랜더링 구현

### ✅ 선택한 책의 북밋 리스트 랜더링

책을 선택할 시 해당 책에 대한 북밋 리스트를 불러옵니다.
선택한 책에 대한 북밋 리스트를 불러오는 로직은 src/api에 getSelectedBookmits로 분리해두었습니다.
getSelectedBookmits 함수는 로컬스토리지와 filter 함수를 이용하여 선택한 책의 북밋만을 불러옵니다.

### ✅ 선택한 책의 북밋이 없을 시의 안내 문구 구현

선택한 책에 북밋이 하나도 없다면 `작성한 북밋이 없어요`라는 문구가 활성화됩니다.

<br/>
<br/>

## 참고 사항

### 연관된 이슈

Close #14 

### 직접적으로 도움이 된 문서

[DEV - How to use Local Storage in Next.js](https://dev.to/collegewap/how-to-use-local-storage-in-nextjs-2l2j)