### PR TITLE
feat: 북밋 생성 기능 구현 (1h/4h)

### DIFF
--- a/app/(home)/bookmit/confirm/page.tsx
+++ b/app/(home)/bookmit/confirm/page.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useState } from "react";
+import { LargeButton, BookInfoCard } from "@/src/components";
+import { postBookmit } from "@/src/api";
+
+export default function BookmitCreate() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+
+  const title = searchParams.get("title")!;
+  const isbn = searchParams.get("isbn")!;
+  const startPage = Number(searchParams.get("startpage")!);
+  const endPage = Number(searchParams.get("endpage")!);
+
+  const onSubmit = () => {
+    postBookmit(title, isbn, startPage, endPage);
+    router.push("/");
+  };
+
+  return (
+    <main className="relative  flex h-full flex-col gap-4 py-16">
+      <h1 className="mb-4 text-2xl font-bold">이 기록을 등록할까요?</h1>
+      <div className="flex w-full justify-between">
+        <span className="text-sm text-neutral-400">책 제목</span>
+        <span className="text-sm font-bold">{searchParams.get("title")}</span>
+      </div>
+      <div className="flex w-full justify-between">
+        <span className="text-sm text-neutral-400">시작 페이지</span>
+        <span className="text-sm font-bold">
+          {searchParams.get("startpage")}
+        </span>
+      </div>
+      <div className="flex w-full justify-between">
+        <span className="text-sm text-neutral-400">마지막 페이지</span>
+        <span className="text-sm font-bold">{searchParams.get("endpage")}</span>
+      </div>
+
+      <div className="absolute bottom-28 flex w-full flex-col justify-center gap-4">
+        <LargeButton onClick={onSubmit}>북밋 생성하기</LargeButton>
+        <Link href="/" className="w-full text-center">
+          <button className=" text-neutral-400">생성 취소</button>
+        </Link>
+      </div>
+    </main>
+  );
+}

--- a/app/(home)/bookmit/create/page.tsx
+++ b/app/(home)/bookmit/create/page.tsx
@@ -1,3 +1,70 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter, useSearchParams } from "next/navigation";
+import { ChangeEvent, useState } from "react";
+import { LargeButton } from "@/src/components";
+
 export default function BookmitCreate() {
-  return <div>create new bookmit :D</div>;
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [startPage, setStartPage] = useState<number | undefined>(undefined);
+  const [endPage, setEndPage] = useState<number | undefined>(undefined);
+
+  const handleStartPage = (e: ChangeEvent<HTMLInputElement>) => {
+    const value = Number(e.currentTarget.value);
+    if (!value) {
+      setStartPage(() => undefined);
+      return;
+    }
+    setStartPage(() => (!isNaN(value) ? value : undefined));
+  };
+
+  const handleEndPage = (e: ChangeEvent<HTMLInputElement>) => {
+    const value = Number(e.currentTarget.value);
+    if (!value) {
+      setEndPage(() => undefined);
+      return;
+    }
+    setEndPage(() => (!isNaN(value) ? value : undefined));
+  };
+
+  const onSubmit = () => {
+    if (!startPage || !endPage) {
+      alert("페이지를 입력해주세요");
+      return;
+    }
+
+    const isbn = searchParams.get("isbn");
+    const title = searchParams.get("title");
+    router.push(
+      `./confirm?isbn=${isbn}&title=${title}&startpage=${startPage}&endpage=${endPage}`,
+    );
+  };
+
+  return (
+    <main className="relative  flex h-full flex-col gap-4 py-16">
+      <h1 className="mb-4 text-2xl font-bold">페이지 정보를 입력해주세요</h1>
+      <input
+        className="w-3/4 outline-none"
+        type="number"
+        value={startPage}
+        onChange={handleStartPage}
+        placeholder="시작 페이지를 입력해주세요"
+      />
+      <input
+        className="w-3/4 outline-none"
+        type="number"
+        value={endPage}
+        onChange={handleEndPage}
+        placeholder="마지막 페이지를 입력해주세요"
+      />
+      <div className="absolute bottom-28 flex w-full flex-col justify-center gap-4">
+        <LargeButton onClick={onSubmit}>페이지 입력하기</LargeButton>
+        <Link href="/" className="w-full text-center">
+          <button className=" text-neutral-400">입력 취소</button>
+        </Link>
+      </div>
+    </main>
+  );
 }

--- a/app/(home)/bookmit/layout.tsx
+++ b/app/(home)/bookmit/layout.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import { Suspense } from "react";
+
+export default function BookmitLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return <Suspense>{children}</Suspense>;
+}

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -36,3 +36,29 @@ export const getSelectedBookmits = (isbn: string) => {
 
   return selectedBookmits;
 };
+
+export const postBookmit = (
+  title: string,
+  isbn: string,
+  startPage: number,
+  endPage: number,
+) => {
+  let allBookmits = getAllBookmits();
+  const todayDate = new Date().toString().slice(3, 15);
+  if (allBookmits[0].date !== todayDate) {
+    allBookmits = [{ date: todayDate, bookmits: [] }, ...allBookmits];
+  }
+
+  const today = allBookmits[0];
+  const newBookmit = {
+    _id: `${new Date().getTime()}`,
+    bookinfo: {
+      title,
+      isbn,
+    },
+    startPage,
+    endPage,
+  };
+  today.bookmits = [newBookmit, ...today.bookmits];
+  localStorage.setItem("bookmits", JSON.stringify(allBookmits));
+};

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -45,7 +45,7 @@ export const postBookmit = (
 ) => {
   let allBookmits = getAllBookmits();
   const todayDate = new Date().toString().slice(3, 15);
-  if (allBookmits[0].date !== todayDate) {
+  if (!allBookmits.length || allBookmits[0].date !== todayDate) {
     allBookmits = [{ date: todayDate, bookmits: [] }, ...allBookmits];
   }
 


### PR DESCRIPTION
# 북밋 생성 기능 구현

## 기능 미리보기

![2024-02-226 28 44-ezgif com-video-to-gif-converter](https://github.com/MayOwall/bookmit/assets/97934878/add48e34-511f-4f57-bdb8-912ea34243c2)


### ✅ 페이지 정보 입력하기

페이지 정보를 입력할 수 있습니다.
페이지 정보는 숫자만 입력 가능하도록 했습니다.

페이지 입력하기 버튼을 누르면 북밋 생성 확인 페이지로 이동할 수 있습니다.
이때, 페이지 정보가 둘 중 하나라도 없다면 북밋 생성 확인 페이지로 이동할 수 없습니다.

입력 취소 버튼을 누르면 메인 페이지로 이동합니다.


#### 상세 설명

책 제목, isbn, 시작 페이지, 마지막 페이지의 정보는 url의 Params를 통해 전달합니다.

<br/>

### ✅ 페이지 입력 확인 및 북밋 생성하기

앞서 입력한 페이지 정보와 책 정보를 확인 할 수 있습니다.

북밋 생성하기 버튼을 누르면 북밋이 생성되며 홈 페이지로 이동합니다.
북밋 취소 버튼을 누르면 홈 페이지로 이동합니다.

<br/>
<br/>

## 참고 사항

### 관련 이슈

Close #16 

### 직접적으로 도움이 된 문서

[Next 공식문서 - useSearchParams](https://nextjs.org/docs/app/api-reference/functions/use-search-params)
[Next 공식문서 - Missing Suspense Boundary with useSearchParams](https://nextjs.org/docs/messages/missing-suspense-with-csr-bailout)