### PR TITLE
feat: 오늘의 독서 기록 권장 컴포넌트 구현

### DIFF
--- a/FE/app/(home)/calendar/page.tsx
+++ b/FE/app/(home)/calendar/page.tsx
@@ -1,8 +1,20 @@
-import { Calendar } from "@/src/components";
+"use client";
+
+import { useEffect, useState } from "react";
+import { Calendar, WriteRecommendation } from "@/src/components";
+import { getIsTodayBookRecordExist } from "@/src/api";
 
 export default function CalendarPage() {
+  const [isTodayBookRecordExist, setIsTodayBookRecordExist] = useState(false);
+
+  useEffect(() => {
+    const data = getIsTodayBookRecordExist();
+    setIsTodayBookRecordExist(() => data);
+  }, []);
+
   return (
     <main>
+      {!isTodayBookRecordExist && <WriteRecommendation />}
       <Calendar />
     </main>
   );

--- a/FE/app/(home)/write/record/create/confirm/page.tsx
+++ b/FE/app/(home)/write/record/create/confirm/page.tsx
@@ -16,7 +16,7 @@ export default function BookmitCreate() {
 
   const onSubmit = () => {
     postBookmit(title, isbn, startPage, endPage);
-    router.push("/write");
+    router.push("/calendar");
   };
 
   return (

--- a/FE/src/api/index.ts
+++ b/FE/src/api/index.ts
@@ -107,3 +107,11 @@ export const postBookmit = (
   ]);
   localStorage.setItem("book-records", nextLocalBookRecords);
 };
+
+export const getIsTodayBookRecordExist = () => {
+  const today = new Date().toDateString();
+  const bookRecords = getAllBookRecords();
+  const isTodayBookRecordExist = !!bookRecords.find((v) => v.date === today);
+
+  return isTodayBookRecordExist;
+};

--- a/FE/src/components/WriteRecommendation/WriteRecommendation.tsx
+++ b/FE/src/components/WriteRecommendation/WriteRecommendation.tsx
@@ -1,0 +1,24 @@
+import Link from "next/link";
+import Image from "next/image";
+
+export default function WriteRecommendation() {
+  return (
+    <Link href="/write">
+      <div className="mb-4 flex w-full flex-col rounded-lg bg-white p-4 pb-3">
+        <span className="text-sm text-neutral-300">
+          아직 오늘의 독서를 기록하지 않았어요.
+        </span>
+        <div className="flex items-center gap-1 text-lg font-bold text-emerald-400">
+          <span>오늘의 독서 기록하러 가기</span>
+          <Image
+            src="/icons/arrowdown-icon-default.svg"
+            width={15}
+            height={15}
+            style={{ transform: "rotate(-90deg)" }}
+            alt="오늘의 독서 기록하러 가기"
+          />
+        </div>
+      </div>
+    </Link>
+  );
+}

--- a/FE/src/components/index.ts
+++ b/FE/src/components/index.ts
@@ -9,6 +9,7 @@ import BottomBar from "./BottomBar/BottomBar";
 import Icon from "./Icon/Icon";
 import BookRecordsByDate from "./BookRecordsByDate/BookRecordsByDate";
 import Calendar from "./Calendar/Calendar";
+import WriteRecommendation from "./WriteRecommendation/WriteRecommendation";
 
 export {
   ReadingBookShelf,
@@ -22,4 +23,5 @@ export {
   Icon,
   BookRecordsByDate,
   Calendar,
+  WriteRecommendation,
 };


### PR DESCRIPTION
## 구현 사항

### 오늘의 독서 기록 권장 컴포넌트 구현

- 오늘의 독서 기록을 권장하는 컴포넌트를 구현했습니다.
아직 오늘의 독서 기록이 없을 시 해당 컴포넌트가 캘린더 페이지 상단에 나타나게 됩니다.

<img width="416" alt="image" src="https://github.com/MayOwall/bookmit/assets/97934878/be077e43-4192-4bc3-9ffc-28ce086f7f67">

### 그 외 

- 독서 내용을 기록한 후에 라우팅되는 페이지를 작성 페이지에서 캘린더 페이지로 변경했습니다.

<br/>

## 참고 사항

### 관련 이슈

Close #43 